### PR TITLE
Persist user and tab state

### DIFF
--- a/project-bolt-sb1-u6rhzimz/project/src/App.tsx
+++ b/project-bolt-sb1-u6rhzimz/project/src/App.tsx
@@ -13,9 +13,9 @@ function App() {
   const [posts, setPosts] = useState<Post[]>([]);
 
   useEffect(() => {
-    const stored = localStorage.getItem('posts');
-    if (stored) {
-      const parsed: Post[] = JSON.parse(stored);
+    const storedPosts = localStorage.getItem('posts');
+    if (storedPosts) {
+      const parsed: Post[] = JSON.parse(storedPosts);
       const postsWithDates = parsed.map(post => ({
         ...post,
         createdAt: new Date(post.createdAt),
@@ -26,11 +26,33 @@ function App() {
       }));
       setPosts(postsWithDates);
     }
+
+    const storedUser = localStorage.getItem('user');
+    if (storedUser) {
+      try {
+        setUser(JSON.parse(storedUser));
+      } catch {
+        // ignore parsing errors
+      }
+    }
+
+    const storedTab = localStorage.getItem('activeTab');
+    if (storedTab === 'vida-loca' || storedTab === 'profile') {
+      setActiveTab(storedTab as Tab);
+    }
   }, []);
 
   useEffect(() => {
     localStorage.setItem('posts', JSON.stringify(posts));
   }, [posts]);
+
+  useEffect(() => {
+    localStorage.setItem('user', JSON.stringify(user));
+  }, [user]);
+
+  useEffect(() => {
+    localStorage.setItem('activeTab', activeTab);
+  }, [activeTab]);
 
   const handlePost = (content: string) => {
     const newPost: Post = {


### PR DESCRIPTION
## Summary
- persist user profile and currently active tab in `localStorage`
- load stored user and tab on startup along with posts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855e67fd0688320845db1b422b9c120